### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "vite": "^3.1.0"
   },
   "dependencies": {
+    "ansis": "^3.12.0",
     "debug": "^4.3.4",
-    "picocolors": "^1.0.0",
     "playwright": "^1.25.2",
     "sirv": "^2.0.2",
     "ufo": "^0.8.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,11 +10,11 @@ importers:
       '@types/debug': ^4.1.7
       '@types/node': ^18.7.18
       '@types/polka': ^0.5.4
+      ansis: ^3.12.0
       bumpp: ^8.2.1
       debug: ^4.3.4
       eslint: ^8.23.1
       esno: ^0.16.3
-      picocolors: ^1.0.0
       playwright: ^1.25.2
       pnpm: ^7.12.0
       rimraf: ^3.0.2
@@ -25,8 +25,8 @@ importers:
       vite: ^3.1.2
       vitest: ^0.23.4
     dependencies:
+      ansis: 3.12.0
       debug: 4.3.4
-      picocolors: 1.0.0
       playwright: 1.25.2
       sirv: 2.0.2
       ufo: 0.8.5
@@ -1195,6 +1195,11 @@ packages:
     dependencies:
       color-convert: 2.0.1
     dev: true
+
+  /ansis/3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
+    dev: false
 
   /anymatch/3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-console */
-import c from 'picocolors'
+import c from 'ansis'
 import type { RuntimeErrorLog } from './types'
 
 export function printErrorLogs(logs: RuntimeErrorLog[]) {
   if (!logs.length) {
     console.log()
-    console.log(c.inverse(c.bold(c.green(' DEPLOY CHECK '))) + c.green(' No runtime errors found'))
+    console.log(c.inverse.bold.green(' DEPLOY CHECK ') + c.green(' No runtime errors found'))
     return
   }
   console.error()
-  console.error(c.inverse(c.bold(c.red(' DEPLOY CHECK '))) + c.red(` ${logs.length} Runtime errors found`))
+  console.error(c.inverse.bold.red(' DEPLOY CHECK ') + c.red` ${logs.length} Runtime errors found`)
   logs.forEach((log, idx) => {
-    console.error(c.yellow(`\n--- Error ${idx + 1} -------- ${c.gray(new Date(log.timestamp).toLocaleTimeString())} ---`))
+    console.error(c.yellow`\n--- Error ${idx + 1} -------- ${c.gray(new Date(log.timestamp).toLocaleTimeString())} ---`)
     if (log.type === 'page-error')
       console.error(log.error)
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).
